### PR TITLE
ASTC support for cabinets

### DIFF
--- a/Assets/curif/LibRetroWrapper/Cabinet.cs
+++ b/Assets/curif/LibRetroWrapper/Cabinet.cs
@@ -7,13 +7,13 @@ You should have received a copy of the GNU General Public License along with thi
 using UnityEngine;
 using System.Collections.Generic;
 using System.IO;
-using System.ComponentModel;
 using System;
-using System.Collections.Specialized;
 
 
 public static class CabinetTextureCache
 {
+    private static byte[] astcMagicNumber = new byte[] { 0x13, 0xAB, 0xA1, 0x5C };
+
     // Dictionary to store cached textures
     private static Dictionary<string, Texture2D> cachedTextures = new Dictionary<string, Texture2D>();
 
@@ -22,15 +22,36 @@ public static class CabinetTextureCache
     {
         if (!IsTextureCached(path))
         {
-            Texture2D tex = null;
-            byte[] fileData;
+            Texture2D tex;
 
             // Load the texture from disk
-            fileData = File.ReadAllBytes(path);
-            tex = new Texture2D(2, 2, TextureFormat.RGB565, true);
-            tex.filterMode = FilterMode.Trilinear; //provides better mip transitions in VR
-            tex.mipMapBias = -0.3f; // setting mip bias to around -0.7 in Unity is recommended by meta for high-detail textures
-            tex.LoadImage(fileData); //..this will auto-resize the texture dimensions.
+            byte[] fileData = File.ReadAllBytes(path);
+            if (path.EndsWith(".astc", StringComparison.OrdinalIgnoreCase))
+            {
+                // Check for 16 bytes header. Skip if needed.  https://github.com/ARM-software/astc-encoder/blob/main/Docs/FileFormat.md
+                if (!StartsWithMagicNumber(fileData, astcMagicNumber))
+                {
+                    ConfigManager.WriteConsoleError($"[CabinetTextureCache.LoadAndCacheTexture] {path} is a valid ASTC texture.");
+                    throw new IOException();
+                }
+                int width = fileData[7] | (fileData[8] << 8) | (fileData[9] << 16);
+                int height = fileData[10] | (fileData[11] << 8) | (fileData[12] << 16);
+                ConfigManager.WriteConsole($"[CabinetTextureCache.LoadAndCacheTexture] {path} texture size:{width}x{height}");
+                tex = new Texture2D(width, height, TextureFormat.ASTC_6x6, false, false);
+                tex.filterMode = FilterMode.Trilinear; //provides better mip transitions in VR
+                tex.mipMapBias = -0.3f; // setting mip bias to around -0.7 in Unity is recommended by meta for high-detail textures
+                tex.LoadRawTextureData(fileData);
+            }
+            else
+            {
+                ConfigManager.WriteConsoleError($"[CabinetTextureCache.LoadAndCacheTexture] {path} is an RGB texture.");
+                tex = new Texture2D(512, 512, TextureFormat.RGB565, true);
+                tex.filterMode = FilterMode.Trilinear; //provides better mip transitions in VR
+                tex.mipMapBias = -0.3f; // setting mip bias to around -0.7 in Unity is recommended by meta for high-detail textures
+                tex.LoadImage(fileData); //..this will auto-resize the texture dimensions.
+            }
+            tex.Apply();
+
 
             // Cache the loaded texture
             cachedTextures.Add(path, tex);
@@ -39,6 +60,24 @@ public static class CabinetTextureCache
         }
 
         return GetCachedTexture(path);
+    }
+
+    private static bool StartsWithMagicNumber(byte[] byteArray, byte[] magicNumber)
+    {
+        if (byteArray == null || byteArray.Length < magicNumber.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < magicNumber.Length; i++)
+        {
+            if (byteArray[i] != magicNumber[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     // Method to retrieve a cached texture


### PR DESCRIPTION
Support for ASTC textures for cabinets

These need to have the ".astc" extension and be produced with astcencode (https://github.com/ARM-software/astc-encoder) with the following settings :

astcenc-avx2.exe -cl "texture.png" "texture.astc" 6x6 -exhaustive -yflip

Then all that's left is referencing the .astc file instead of the .png in the description. yaml manifest.