### PR TITLE
control schemes (ex: "control-scheme: 6-buttons" in description.yaml)

### DIFF
--- a/Assets/curif/LibRetroWrapper/Cabinet.cs
+++ b/Assets/curif/LibRetroWrapper/Cabinet.cs
@@ -107,6 +107,7 @@ public static class CabinetTextureCache
 public class Cabinet
 {
     public string Name = "";
+    public string ControlScheme = "";
     public GameObject gameObject;
 
     //Al the parts in the gabinet that must exists, can be others.
@@ -378,10 +379,11 @@ public class Cabinet
         return onFloor;
     }
 
-    public Cabinet(string name, Vector3 position, Quaternion rotation, Transform parent,
+    public Cabinet(string name, string controlScheme, Vector3 position, Quaternion rotation, Transform parent,
                         GameObject go = null, string model = "galaga")
     {
         Name = name;
+        ControlScheme = controlScheme;
         if (go == null)
         {
             // Assets/Resources/Cabinets/PreFab/xxx.prefab

--- a/Assets/curif/LibRetroWrapper/CabinetFactory.cs
+++ b/Assets/curif/LibRetroWrapper/CabinetFactory.cs
@@ -39,7 +39,7 @@ public static class CabinetFactory
         CabinetStyles.Add("cocktail", Resources.Load<GameObject>($"Cabinets/PreFab/Cocktail"));
     }
 
-    public static Cabinet Factory(string style, string name, string modelFilePath,
+    public static Cabinet Factory(string style, string name, string controlScheme, string modelFilePath,
                                     int number, string room, Vector3 position,
                                     Quaternion rotation, Transform parent,
                                     bool cacheGlbModels = true)
@@ -98,7 +98,7 @@ public static class CabinetFactory
         string cabinetName = $"cabinet-{name}-{room}-{number}";
 
 
-        return new Cabinet(cabinetName, position, rotation, parent, go: model);
+        return new Cabinet(cabinetName, controlScheme, position, rotation, parent, go: model);
     }
 
     public static string BuildKey(string modelFilePath)
@@ -244,7 +244,7 @@ public static class CabinetFactory
             }
         }
 
-        Cabinet cabinet = CabinetFactory.Factory(cbinfo.style, cbinfo.name, modelFilePath,
+        Cabinet cabinet = CabinetFactory.Factory(cbinfo.style, cbinfo.name, cbinfo.controlScheme, modelFilePath,
                                                     number, room, position, rotation, parent,
                                                     cacheGlbModels: cacheGlbModels);
 

--- a/Assets/curif/LibRetroWrapper/CabinetInformation.cs
+++ b/Assets/curif/LibRetroWrapper/CabinetInformation.cs
@@ -68,6 +68,9 @@ public class CabinetInformation
     [YamlMember(Alias = "debug-mode", ApplyNamingConventions = false)]
     public bool debug = false;
 
+    [YamlMember(Alias = "control-scheme", ApplyNamingConventions = false)]
+    public string controlScheme;
+
     [YamlIgnore]
     public string pathBase;
 

--- a/Assets/curif/LibRetroWrapper/ConfigManager.cs
+++ b/Assets/curif/LibRetroWrapper/ConfigManager.cs
@@ -12,9 +12,9 @@ You should have received a copy of the GNU General Public License along with thi
 #define DEBUG_ACTIVE
 #endif
 
-using UnityEngine;
-using System.IO;
 using System;
+using System.IO;
+using UnityEngine;
 
 public static class ConfigManager
 {
@@ -26,30 +26,31 @@ public static class ConfigManager
 #endif
 
     public static string Cabinets = Path.Combine(BaseDir, "cabinets"); //$"{BaseDir}/cabinets"; //compressed
-    public static string CabinetsDB = Path.Combine(BaseDir,"cabinetsdb"); //uncompressed cabinets
-    public static string SystemDir = Path.Combine(BaseDir,"system");
-    public static string RomsDir = Path.Combine(BaseDir,"downloads");
-    public static string GameSaveDir = Path.Combine(BaseDir,"save");
+    public static string CabinetsDB = Path.Combine(BaseDir, "cabinetsdb"); //uncompressed cabinets
+    public static string SystemDir = Path.Combine(BaseDir, "system");
+    public static string RomsDir = Path.Combine(BaseDir, "downloads");
+    public static string GameSaveDir = Path.Combine(BaseDir, "save");
     public static string GameStatesDir = Path.Combine(BaseDir, "startstates");
-    public static string ConfigDir = Path.Combine(BaseDir,"configuration");
+    public static string ConfigDir = Path.Combine(BaseDir, "configuration");
     public static string ConfigControllersDir = Path.Combine(ConfigDir, "controllers");
-    public static string AGEBasicDir = Path.Combine(BaseDir,"AGEBasic");
-    public static string DebugDir = Path.Combine(BaseDir,"debug");
-    public static string SamplesDir = Path.Combine(SystemDir,"samples");
-    public static string MameConfigDir = Path.Combine(GameSaveDir,"cfg");
-    public static string nvramDir = Path.Combine(GameSaveDir,"nvram");
-    public static string MusicDir = Path.Combine(BaseDir,"music");
+    public static string ConfigControllerSchemesDir = Path.Combine(ConfigDir, "controllers/schemes");
+    public static string AGEBasicDir = Path.Combine(BaseDir, "AGEBasic");
+    public static string DebugDir = Path.Combine(BaseDir, "debug");
+    public static string SamplesDir = Path.Combine(SystemDir, "samples");
+    public static string MameConfigDir = Path.Combine(GameSaveDir, "cfg");
+    public static string nvramDir = Path.Combine(GameSaveDir, "nvram");
+    public static string MusicDir = Path.Combine(BaseDir, "music");
 
     public static ConfigInformation configuration;
     public static bool DebugActive
     {
         get
         {
-            #if DEBUG_ACTIVE
+#if DEBUG_ACTIVE
             return true;
-            #else
+#else
             return false;
-            #endif
+#endif
         }
     }
 
@@ -57,34 +58,27 @@ public static class ConfigManager
     {
         Debug.Log($"[ConfigManager] BaseDir {BaseDir}");
 
-        if (!Directory.Exists(ConfigManager.Cabinets))
-            Directory.CreateDirectory(ConfigManager.Cabinets);
-        if (!Directory.Exists(ConfigManager.CabinetsDB))
-            Directory.CreateDirectory(ConfigManager.CabinetsDB);
-        if (!Directory.Exists(ConfigManager.ConfigDir))
-            Directory.CreateDirectory(ConfigManager.ConfigDir);
-        if (!Directory.Exists(ConfigManager.ConfigControllersDir))
-            Directory.CreateDirectory(ConfigManager.ConfigControllersDir);
-        if (!Directory.Exists(ConfigManager.AGEBasicDir))
-            Directory.CreateDirectory(ConfigManager.AGEBasicDir);
-        if (!Directory.Exists(ConfigManager.DebugDir))
-            Directory.CreateDirectory(ConfigManager.DebugDir);
-        if (!Directory.Exists(ConfigManager.MusicDir))
-            Directory.CreateDirectory(ConfigManager.MusicDir);
+        CreateDirectory(ConfigManager.Cabinets);
+        CreateDirectory(ConfigManager.CabinetsDB);
+        CreateDirectory(ConfigManager.ConfigDir);
+        CreateDirectory(ConfigManager.ConfigControllersDir);
+        CreateDirectory(ConfigManager.ConfigControllerSchemesDir);
+        CreateDirectory(ConfigManager.AGEBasicDir);
+        CreateDirectory(ConfigManager.DebugDir);
+        CreateDirectory(ConfigManager.MusicDir);
 
-        if (!Directory.Exists(ConfigManager.SystemDir))
-            Directory.CreateDirectory(ConfigManager.SystemDir);
-        if (!Directory.Exists(ConfigManager.RomsDir))
-            Directory.CreateDirectory(ConfigManager.RomsDir);
-        if (!Directory.Exists(ConfigManager.GameSaveDir))
-            Directory.CreateDirectory(ConfigManager.GameSaveDir);
-        if (!Directory.Exists(ConfigManager.SamplesDir))
-            Directory.CreateDirectory(ConfigManager.SamplesDir);
-        if (!Directory.Exists(ConfigManager.MameConfigDir))
-            Directory.CreateDirectory(ConfigManager.MameConfigDir);
-        if (!Directory.Exists(ConfigManager.nvramDir))
-            Directory.CreateDirectory(ConfigManager.nvramDir);
+        CreateDirectory(ConfigManager.SystemDir);
+        CreateDirectory(ConfigManager.RomsDir);
+        CreateDirectory(ConfigManager.GameSaveDir);
+        CreateDirectory(ConfigManager.SamplesDir);
+        CreateDirectory(ConfigManager.MameConfigDir);
+        CreateDirectory(ConfigManager.nvramDir);
+    }
 
+    public static void CreateDirectory(string path)
+    {
+        if (!Directory.Exists(path))
+            Directory.CreateDirectory(path);
     }
 
     /*
@@ -95,32 +89,31 @@ public static class ConfigManager
 
     public static void WriteConsole(string st)
     {
-        #if DEBUG_ACTIVE
+#if DEBUG_ACTIVE
         UnityEngine.Debug.LogFormat(LogType.Log, LogOption.NoStacktrace, null, "[AGE] {0}", st);
-        #endif
+#endif
     }
     // [System.Diagnostics.Conditional("DEBUG_ACTIVE")]
     public static void WriteConsoleError(string st)
     {
-        #if DEBUG_ACTIVE
+#if DEBUG_ACTIVE
         UnityEngine.Debug.LogFormat(LogType.Error, LogOption.None, null, "[AGE ERROR] {0}", st);
-        #endif
+#endif
     }
     // [System.Diagnostics.Conditional("DEBUG_ACTIVE")]
     public static void WriteConsoleWarning(string st)
     {
-        #if DEBUG_ACTIVE
+#if DEBUG_ACTIVE
         UnityEngine.Debug.LogFormat(LogType.Warning, LogOption.None, null, "[AGE WARNING] {0}", st);
-        #endif
+#endif
     }
     // [System.Diagnostics.Conditional("DEBUG_ACTIVE")]
     public static void WriteConsoleException(string st, Exception e)
     {
-        #if DEBUG_ACTIVE
+#if DEBUG_ACTIVE
         UnityEngine.Debug.LogFormat(LogType.Exception, LogOption.None, null,
                     "[AGE ERROR EXCEPTION] {0} Exception {1} StackTrace: \n {2}", st, e, e.StackTrace);
-        #endif
+#endif
     }
 
 }
- 

--- a/Assets/curif/LibRetroWrapper/ControlMapConfiguration.cs
+++ b/Assets/curif/LibRetroWrapper/ControlMapConfiguration.cs
@@ -1,12 +1,6 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System;
-using UnityEngine;
-using UnityEngine.XR.Interaction.Toolkit.Inputs;
-using UnityEngine.XR;
-using UnityEngine.XR.Interaction.Toolkit;
-using UnityEngine.InputSystem;
 using System.Text;
 using System.IO;
 using YamlDotNet.Serialization;
@@ -357,6 +351,39 @@ public class GameControlMap : GlobalControlMap
     {
         ControlMapConfiguration gameConfig = ControlMapConfiguration.LoadFromYaml(getFileName());
         Merge(gameConfig);
+    }
+}
+
+public class ControlSchemeControlMap : DefaultControlMap
+{
+    private string controlScheme;
+    public ControlSchemeControlMap(string controlScheme) : base()
+    {
+        this.controlScheme = controlScheme;
+        Load();
+    }
+
+    public static string Path(string controlScheme)
+    {
+        return ConfigManager.ConfigControllerSchemesDir + "/" + controlScheme + ".yaml";
+    }
+
+    private string getFileName()
+    {
+        return Path(controlScheme);
+    }
+
+    public static bool ExistsConfiguration(string controlScheme)
+    {
+        string path = Path(controlScheme);
+        bool exists = File.Exists(Path(controlScheme));
+        ConfigManager.WriteConsole($"[GameControlMap] configuration exists for control scheme {controlScheme}: {exists}");
+        return exists;
+    }
+    public override void Load()
+    {
+        ControlMapConfiguration schemeConfig = ControlMapConfiguration.LoadFromYaml(getFileName());
+        Merge(schemeConfig);
     }
 }
 

--- a/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
@@ -284,6 +284,12 @@ public class LibretroScreenController : MonoBehaviour
                       ConfigManager.WriteConsole($"[LibretroScreenController] loading user controller configuration, GameControlMap: {cabinetReplace.game.CabinetDBName}");
                       controlConf = new GameControlMap(cabinetReplace.game.CabinetDBName);
                   }
+                  else if (!string.IsNullOrEmpty(cabinetReplace.cabinet?.ControlScheme) &&
+                             ControlSchemeControlMap.ExistsConfiguration(cabinetReplace.cabinet.ControlScheme))
+                  {
+                      ConfigManager.WriteConsole($"[LibretroScreenController] loading control scheme configuration, ControlSchemeControlMap: {cabinetReplace.cabinet.ControlScheme}");
+                      controlConf = new ControlSchemeControlMap(cabinetReplace.cabinet.ControlScheme);
+                  }
                   else
                   {
                       ConfigManager.WriteConsole($"[LibretroScreenController] no controller user configuration, no cabinet configuration, using GlobalControlMap");
@@ -294,7 +300,7 @@ public class LibretroScreenController : MonoBehaviour
                   libretroControlMap.CreateFromConfiguration(controlConf);
                   LibretroMameCore.ControlMap = libretroControlMap;
 
-                  // Ligth guns configuration
+                  // Light guns configuration
                   if (lightGunTarget != null && lightGunInformation != null)
                   {
                       lightGunTarget.Init(lightGunInformation, PathBase);


### PR DESCRIPTION
Add control scheme support.

A cab's description.yaml can be enriched with a control-scheme setting.
Example: `control-scheme: 6-buttons`

If set, this specifies a controller yaml configuration file to apply to this cab. Control schemes are located in /configuration/controllers/schemes (this directory is auto-created)
Example: `/configuration/controllers/schemes/6-buttons.yaml`

*NOTE: If the description.yaml specifies a control map, it takes precedance. The scheme is functionally ignored.*

Priority goes : description.yaml map > user game map > scheme map > global map