### PR TITLE
Shader configuration file

### DIFF
--- a/Assets/curif/LibRetroWrapper/LibretroMameCore.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroMameCore.cs
@@ -618,6 +618,7 @@ public static unsafe class LibretroMameCore
             RecreateTexture = false;
             //some shaders needs to refresh the texture once recreated.
             Shader.Refresh(GameTexture);
+            Shader.ApplyConfiguration();
             return true;
         }
         return false;

--- a/Assets/curif/LibRetroWrapper/MaterialsConfiguration.cs
+++ b/Assets/curif/LibRetroWrapper/MaterialsConfiguration.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public class MaterialsConfiguration
+{
+    public List<MaterialConfiguration> materials = new List<MaterialConfiguration>();
+
+    public class MaterialConfiguration
+    {
+        public string name;
+        public Dictionary<string, object> properties = new Dictionary<string, object>();
+    }
+}

--- a/Assets/curif/LibRetroWrapper/MaterialsConfiguration.cs.meta
+++ b/Assets/curif/LibRetroWrapper/MaterialsConfiguration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0c9c01f4decf7343a09b1ec7fea0ed7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/curif/LibRetroWrapper/MaterialsUtils.cs
+++ b/Assets/curif/LibRetroWrapper/MaterialsUtils.cs
@@ -1,0 +1,135 @@
+using UnityEngine;
+using UnityEditor;
+using static MaterialsConfiguration;
+using System.Collections.Generic;
+using System.IO;
+using System.Globalization;
+
+public class MaterialsUtils
+{
+    public static void ApplyConfiguration(Material material)
+    {
+        MaterialsConfiguration materialsConfiguration = LoadConfiguration();
+        if (materialsConfiguration != null)
+        {
+            MaterialConfiguration materialConfiguration = materialsConfiguration.materials.Find(x => x.name == material.name);
+            if (materialConfiguration == null)
+            {
+                ConfigManager.WriteConsole($"[MaterialsUtils] {material.name}: No configuration found");
+                return;
+            }
+            ConfigManager.WriteConsole($"[MaterialsUtils] Applying configuration for {material.name}");
+            foreach (KeyValuePair<string, object> entry in materialConfiguration.properties)
+            {
+                SetShaderValue(material, entry.Key, entry.Value.ToString());
+            }
+        }
+    }
+
+    private static object GetShaderValue(Material material, string propertyName)
+    {
+        int index = GetPropertyIndex(material, propertyName);
+        if (index == -1)
+        {
+            ConfigManager.WriteConsole($"[MaterialsUtils] SetShaderValue {material.name}: Unknown property: {propertyName}");
+            return null;
+        }
+        Shader shader = material.shader;
+        ShaderUtil.ShaderPropertyType propertyType = ShaderUtil.GetPropertyType(shader, index);
+        object propertyValue = null;
+        if (propertyType == ShaderUtil.ShaderPropertyType.Range || propertyType == ShaderUtil.ShaderPropertyType.Float)
+        {
+            propertyValue = material.GetFloat(propertyName);
+        }
+        else if (propertyType == ShaderUtil.ShaderPropertyType.Color)
+        {
+            propertyValue = material.GetColor(propertyName);
+        }
+        else if (propertyType == ShaderUtil.ShaderPropertyType.Vector)
+        {
+            propertyValue = material.GetVector(propertyName);
+        }
+        else if (propertyType == ShaderUtil.ShaderPropertyType.TexEnv)
+        {
+            propertyValue = material.GetTexture(propertyName);
+        }
+        return propertyValue;
+    }
+
+    private static void SetShaderValue(Material material, string propertyName, string propertyValue)
+    {
+        int index = GetPropertyIndex(material, propertyName);
+        if (index == -1)
+        {
+            ConfigManager.WriteConsole($"[MaterialsUtils] SetShaderValue {material.name}: Unknown property: {propertyName}");
+            return;
+        }
+        Shader shader = material.shader;
+        ShaderUtil.ShaderPropertyType propertyType = ShaderUtil.GetPropertyType(shader, index);
+        if (propertyType == ShaderUtil.ShaderPropertyType.Range || propertyType == ShaderUtil.ShaderPropertyType.Float)
+        {
+            ConfigManager.WriteConsole($"[MaterialsUtils] SetShaderValue {material.name} {propertyName}: {propertyValue}");
+            material.SetFloat(propertyName, float.Parse(propertyValue, CultureInfo.InvariantCulture));
+        }
+        else
+        {
+            ConfigManager.WriteConsole($"[MaterialsUtils] SetShaderValue {material.name} {propertyName}: Unsupported operation for property type {propertyType}");
+        }
+    }
+
+    private static int GetPropertyIndex(Material material, string propertyName)
+    {
+        Shader shader = material.shader;
+        int propertyCount = ShaderUtil.GetPropertyCount(shader);
+        for (int i = 0; i < propertyCount; i++)
+        {
+            string name = ShaderUtil.GetPropertyName(shader, i);
+            if (name == propertyName)
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static MaterialsConfiguration LoadConfiguration()
+    {
+        return YamlUtils.ParseOptional<MaterialsConfiguration>(Path.Combine(ConfigManager.ConfigDir, "materials.yaml"));
+    }
+
+    // Used to dump all properties of a material to the console. For Dev purposes
+    public static void ListShaderValues(Material material)
+    {
+        Shader shader = material.shader;
+        int propertyCount = ShaderUtil.GetPropertyCount(shader);
+        for (int i = 0; i < propertyCount; i++)
+        {
+            string propertyName = ShaderUtil.GetPropertyName(shader, i);
+            ShaderUtil.ShaderPropertyType propertyType = ShaderUtil.GetPropertyType(shader, i);
+            object propertyValue = GetShaderValue(material, propertyName);
+            ConfigManager.WriteConsole($"[MaterialsUtils] Shader {material.name} property {propertyType} {propertyName} = {propertyValue}");
+        }
+    }
+
+    // Used to generate a fresh, correct, new materials.yaml file for a given material. For Dev purposes
+    public static void SaveConfiguration(Material material)
+    {
+        MaterialsConfiguration materialsConfiguration = new MaterialsConfiguration();
+        MaterialConfiguration materialConfiguration = new MaterialConfiguration();
+        materialConfiguration.name = material.name;
+        Shader shader = material.shader;
+        int propertyCount = ShaderUtil.GetPropertyCount(shader);
+        for (int i = 0; i < propertyCount; i++)
+        {
+            string propertyName = ShaderUtil.GetPropertyName(shader, i);
+            ShaderUtil.ShaderPropertyType propertyType = ShaderUtil.GetPropertyType(shader, i);
+            if (propertyType == ShaderUtil.ShaderPropertyType.Range || propertyType == ShaderUtil.ShaderPropertyType.Float)
+            {
+                object propertyValue = GetShaderValue(material, propertyName);
+                materialConfiguration.properties[propertyName] = propertyValue;
+            }
+        }
+        materialsConfiguration.materials.Add(materialConfiguration);
+        YamlUtils.Save(Path.Combine(ConfigManager.ConfigDir, "materials.yaml"), materialsConfiguration);
+    }
+}

--- a/Assets/curif/LibRetroWrapper/MaterialsUtils.cs.meta
+++ b/Assets/curif/LibRetroWrapper/MaterialsUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71825e98ed29c194f9407c6aa0a7ca51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/curif/LibRetroWrapper/ShaderCRT.cs
+++ b/Assets/curif/LibRetroWrapper/ShaderCRT.cs
@@ -30,7 +30,7 @@ public class ShaderCRT : ShaderScreenBase
         else if (damage == "medium")
             material = MaterialPrefabDamageHigh;
 
-        MaterialsUtils.ApplyConfiguration(material);
+        ApplyConfiguration();
     }
 
     public override string Name

--- a/Assets/curif/LibRetroWrapper/ShaderCRT.cs
+++ b/Assets/curif/LibRetroWrapper/ShaderCRT.cs
@@ -14,11 +14,11 @@ public class ShaderCRT : ShaderScreenBase
 
     static ShaderCRT()
     {
-      Low = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCRTLow");
-      Medium = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCRTMedium");
-      High = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCRTHigh");
+        Low = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCRTLow");
+        Medium = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCRTMedium");
+        High = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCRTHigh");
     }
-    
+
     public ShaderCRT(Renderer display, int position, Dictionary<string, string> config) : base(display, position, config)
     {
 
@@ -30,7 +30,7 @@ public class ShaderCRT : ShaderScreenBase
         else if (damage == "medium")
             material = MaterialPrefabDamageHigh;
 
-        return;
+        MaterialsUtils.ApplyConfiguration(material);
     }
 
     public override string Name

--- a/Assets/curif/LibRetroWrapper/ShaderClean.cs
+++ b/Assets/curif/LibRetroWrapper/ShaderClean.cs
@@ -3,74 +3,77 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.ComponentModel;
 
-public class ShaderScreenClean: ShaderScreenBase
+public class ShaderScreenClean : ShaderScreenBase
 {
-  private bool actual_invertx = false, actual_inverty = false;
-  private string damage = "none";
+    private bool actual_invertx = false, actual_inverty = false;
+    private string damage = "none";
 
-  static Material ScreenCleanScanlinesBigPattern;
-  static Material ScreenCleanScanlinesBlackBorderPattern;
-  static Material ScreenCleanScanlines;
-  static Material ScreenClean;
-  static ShaderScreenClean()
-  {
-    ScreenCleanScanlinesBigPattern = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCleanScanlinesBigPattern");
-    ScreenCleanScanlinesBlackBorderPattern = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCleanScanlinesBlackBorderPattern");
-    ScreenCleanScanlines = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCleanScanlines");
-    ScreenClean = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenClean");
-  }
-  public ShaderScreenClean(Renderer display, int position, Dictionary<string, string> config) : base(display, position, config) 
-  {
-
-    material = ScreenClean;
-
-    config.TryGetValue("damage", out damage);
-    if (damage == "high")
-        material = ScreenCleanScanlinesBigPattern;
-    else if (damage == "medium")
-        material = ScreenCleanScanlinesBlackBorderPattern;
-    else if (damage == "low")
-        material = ScreenCleanScanlines;
-
-    //material = new Material(originalMat);
-    //material.CopyPropertiesFromMaterial(originalMat);
-
-    //material = Object.Instantiate(Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenClean"));
-    //material.name = $"instance-ShaderScreenClean-{damage}";
-
-    // material = new Material(Resources.Load<Material>(materialPrefab));
-    ConfigManager.WriteConsole($"[ShaderScreenClean] assigned material: {material} damage: {damage}");
-    
-    return;
-  }
-
-  public override string Name 
-  {
-    get {
-      return "Clean" + $"({damage})";
-    }
-  }
-
-  public override string TargetMaterialProperty 
-  {
-    get
+    static Material ScreenCleanScanlinesBigPattern;
+    static Material ScreenCleanScanlinesBlackBorderPattern;
+    static Material ScreenCleanScanlines;
+    static Material ScreenClean;
+    static ShaderScreenClean()
     {
-      return "_EmissionMap";
+        ScreenCleanScanlinesBigPattern = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCleanScanlinesBigPattern");
+        ScreenCleanScanlinesBlackBorderPattern = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCleanScanlinesBlackBorderPattern");
+        ScreenCleanScanlines = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenCleanScanlines");
+        ScreenClean = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenClean");
     }
-  }
-
-  public override Texture Texture { 
-    get { 
-      return display.materials[position].GetTexture("_EmissionMap");
-    }
-    set 
+    public ShaderScreenClean(Renderer display, int position, Dictionary<string, string> config) : base(display, position, config)
     {
-      ConfigManager.WriteConsole($"[ShaderScreenClean.Texture] {ToString()} SET tex:{(Texture)value} material: {material}");
 
-      display.materials[position].SetTexture("_EmissionMap", (Texture)value);
-      display.materials[position].SetTexture("_MainTex", (Texture)value);
+        material = ScreenClean;
+
+        config.TryGetValue("damage", out damage);
+        if (damage == "high")
+            material = ScreenCleanScanlinesBigPattern;
+        else if (damage == "medium")
+            material = ScreenCleanScanlinesBlackBorderPattern;
+        else if (damage == "low")
+            material = ScreenCleanScanlines;
+
+        //material = new Material(originalMat);
+        //material.CopyPropertiesFromMaterial(originalMat);
+
+        //material = Object.Instantiate(Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenClean"));
+        //material.name = $"instance-ShaderScreenClean-{damage}";
+
+        // material = new Material(Resources.Load<Material>(materialPrefab));
+        ConfigManager.WriteConsole($"[ShaderScreenClean] assigned material: {material} damage: {damage}");
+
+        MaterialsUtils.ApplyConfiguration(material);
     }
-  }
+
+    public override string Name
+    {
+        get
+        {
+            return "Clean" + $"({damage})";
+        }
+    }
+
+    public override string TargetMaterialProperty
+    {
+        get
+        {
+            return "_EmissionMap";
+        }
+    }
+
+    public override Texture Texture
+    {
+        get
+        {
+            return display.materials[position].GetTexture("_EmissionMap");
+        }
+        set
+        {
+            ConfigManager.WriteConsole($"[ShaderScreenClean.Texture] {ToString()} SET tex:{(Texture)value} material: {material}");
+
+            display.materials[position].SetTexture("_EmissionMap", (Texture)value);
+            display.materials[position].SetTexture("_MainTex", (Texture)value);
+        }
+    }
     public override void Refresh(Texture texture)
     {
         Texture = texture;
@@ -80,13 +83,13 @@ public class ShaderScreenClean: ShaderScreenBase
     }
 
     public override ShaderScreenBase Invert(bool invertx, bool inverty)
-  {
-      ConfigManager.WriteConsole($"[ShaderScreenClean.Invert] {invertx}, {inverty}");
-      Vector2 v2 = new Vector2(invertx? -1f : 1f, inverty? -1f : 1f);
-      display.materials[position].SetTextureScale("_EmissionMap", v2);
-      display.materials[position].SetTextureScale("_MainTex", v2); 
-      actual_invertx = invertx; 
-      actual_inverty = inverty;
-    return this;
-  }
+    {
+        ConfigManager.WriteConsole($"[ShaderScreenClean.Invert] {invertx}, {inverty}");
+        Vector2 v2 = new Vector2(invertx ? -1f : 1f, inverty ? -1f : 1f);
+        display.materials[position].SetTextureScale("_EmissionMap", v2);
+        display.materials[position].SetTextureScale("_MainTex", v2);
+        actual_invertx = invertx;
+        actual_inverty = inverty;
+        return this;
+    }
 }

--- a/Assets/curif/LibRetroWrapper/ShaderClean.cs
+++ b/Assets/curif/LibRetroWrapper/ShaderClean.cs
@@ -41,7 +41,7 @@ public class ShaderScreenClean : ShaderScreenBase
         // material = new Material(Resources.Load<Material>(materialPrefab));
         ConfigManager.WriteConsole($"[ShaderScreenClean] assigned material: {material} damage: {damage}");
 
-        MaterialsUtils.ApplyConfiguration(material);
+        ApplyConfiguration();
     }
 
     public override string Name

--- a/Assets/curif/LibRetroWrapper/ShaderDamage.cs
+++ b/Assets/curif/LibRetroWrapper/ShaderDamage.cs
@@ -4,13 +4,13 @@ using System.Collections.Generic;
 
 public class ShaderScreenDamage : ShaderScreenBase
 {
-  private bool actual_invertx = false, actual_inverty = false;
-  private string damage;
+    private bool actual_invertx = false, actual_inverty = false;
+    private string damage;
 
     static Material DamageLow;
     static Material DamageHigh;
     static Material DamageMedium;
-    
+
     static ShaderScreenDamage()
     {
         DamageLow = Resources.Load<Material>("Cabinets/PreFab/CRTs/ScreenDamageLow");
@@ -19,45 +19,48 @@ public class ShaderScreenDamage : ShaderScreenBase
     }
 
     public ShaderScreenDamage(Renderer display, int position, Dictionary<string, string> config) : base(display, position, config)
-  {
-    string damage;
-    material = DamageLow;
-    config.TryGetValue("damage", out damage);
-
-    if (damage == "high")
-        material = DamageHigh;
-    else if (damage == "medium")
-        material = DamageMedium;
-
-    return;
-  }
-
-  public override string Name 
-  {
-    get {
-      return "damage" + $"({damage})";
-    }
-  }
-  
-  public override string TargetMaterialProperty 
-  {
-    get
     {
-      return "_MainTex";
-    }
-  }
+        string damage;
+        material = DamageLow;
+        config.TryGetValue("damage", out damage);
 
-  public override Texture Texture { 
-    get { 
-      return display.materials[position].GetTexture("_MainTex");
+        if (damage == "high")
+            material = DamageHigh;
+        else if (damage == "medium")
+            material = DamageMedium;
+
+        MaterialsUtils.ApplyConfiguration(material);
     }
-    set 
+
+    public override string Name
     {
-      ConfigManager.WriteConsole($"[ShaderScreenDamage.Texture] SET tex:{(Texture)value} material: {material}");
-
-      display.materials[position].SetTexture("_MainTex", (Texture)value);
+        get
+        {
+            return "damage" + $"({damage})";
+        }
     }
-  }
+
+    public override string TargetMaterialProperty
+    {
+        get
+        {
+            return "_MainTex";
+        }
+    }
+
+    public override Texture Texture
+    {
+        get
+        {
+            return display.materials[position].GetTexture("_MainTex");
+        }
+        set
+        {
+            ConfigManager.WriteConsole($"[ShaderScreenDamage.Texture] SET tex:{(Texture)value} material: {material}");
+
+            display.materials[position].SetTexture("_MainTex", (Texture)value);
+        }
+    }
 
     public override void Refresh(Texture texture)
     {
@@ -67,21 +70,21 @@ public class ShaderScreenDamage : ShaderScreenBase
         display.materials[position].SetFloat("MirrorY", actual_inverty ? 1f : 0f);
     }
 
-    public override void Update() 
+    public override void Update()
     {
         display.materials[position].SetFloat("u_time", Time.fixedTime);
     }
-  
-  public override ShaderScreenBase Invert(bool invertx, bool inverty)
-  {
-    if (actual_invertx != invertx || actual_inverty != inverty)
+
+    public override ShaderScreenBase Invert(bool invertx, bool inverty)
     {
-      ConfigManager.WriteConsole($"[ShaderScreenDamage.Invert] {invertx}, {inverty}");
-      display.materials[position].SetFloat("MirrorX", invertx ? 1f : 0f);
-      display.materials[position].SetFloat("MirrorY", inverty ? 1f : 0f);
-      actual_invertx = invertx; 
-      actual_inverty = inverty;
+        if (actual_invertx != invertx || actual_inverty != inverty)
+        {
+            ConfigManager.WriteConsole($"[ShaderScreenDamage.Invert] {invertx}, {inverty}");
+            display.materials[position].SetFloat("MirrorX", invertx ? 1f : 0f);
+            display.materials[position].SetFloat("MirrorY", inverty ? 1f : 0f);
+            actual_invertx = invertx;
+            actual_inverty = inverty;
+        }
+        return this;
     }
-    return this;
-  }
 }

--- a/Assets/curif/LibRetroWrapper/ShaderDamage.cs
+++ b/Assets/curif/LibRetroWrapper/ShaderDamage.cs
@@ -29,7 +29,7 @@ public class ShaderScreenDamage : ShaderScreenBase
         else if (damage == "medium")
             material = DamageMedium;
 
-        MaterialsUtils.ApplyConfiguration(material);
+        ApplyConfiguration();
     }
 
     public override string Name

--- a/Assets/curif/LibRetroWrapper/ShaderScreen.cs
+++ b/Assets/curif/LibRetroWrapper/ShaderScreen.cs
@@ -55,6 +55,11 @@ public abstract class ShaderScreenBase
 
     public abstract Texture Texture { get; set; }
     public abstract string TargetMaterialProperty { get; }
+
+    public void ApplyConfiguration()
+    {
+        MaterialsUtils.ApplyConfiguration(material);
+    }
 }
 //Factory
 public static class ShaderScreen

--- a/Assets/curif/LibRetroWrapper/YamlUtils.cs
+++ b/Assets/curif/LibRetroWrapper/YamlUtils.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Globalization;
 using System.IO;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -9,6 +13,10 @@ public class YamlUtils
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .IgnoreUnmatchedProperties()
             .Build();
+
+    private static readonly ISerializer serializer = new SerializerBuilder()
+                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                 .Build();
 
     private static string ReadFile(string filePath)
     {
@@ -33,4 +41,9 @@ public class YamlUtils
         return content == null ? default : deserializer.Deserialize<T>(content);
     }
 
+    public static void Save(string yamlPath, object obj)
+    {
+        string yaml = serializer.Serialize(obj);
+        File.WriteAllText(yamlPath, yaml);
+    }
 }


### PR DESCRIPTION
Resides in `/configuration/materials.yaml`

Looks like this for example :

```
materials:
- name: ScreenCRTLow
  properties:
    __dirty: 0
    _Damage_Vignette_Hardness: 0.812
    _Damage_Desaturation: 0.555
    _Damage_VIgnette_Radius: 0.464
    _Scanline_GameScreenBrightness: 2
    _Scanline_Amount: 1
    _Distance_Scanline: 1
    _Distance_Scanline_Power: 5
    _CRTBrightnessFlickerMax: 0
    _CRTBrightnessFlickerMin: 0
    _CRTBrightnessFlickerTime: 18
    _MaskVTXRedOnly: 1
    _Distance_DotMask: 0.1
    _Distance_DotMask_Power: 5
    _Dotmask_GameScreenBrightness: 3.19
    _Dotmask_ScanlineRemoval: 1
    _MipBias: 0.5
```

The file will be re-read and re-applied on every game start. No need to restart AoJ.

TODO: also include this configuration bit in description.yaml files
