### PR TITLE
insert-coin-on-startup setting (cab level, and global config level)

### DIFF
--- a/Assets/curif/LibRetroWrapper/Cabinet.cs
+++ b/Assets/curif/LibRetroWrapper/Cabinet.cs
@@ -888,7 +888,7 @@ public class Cabinet
         BackgroundSoundController backgroundSoundController = _backgroundSoundController;
         string core = cbinfo.core ?? "mame2003+";
         CoreEnvironment coreEnvironment = cbinfo.environment;
-        bool insertCoinOnStartup = cbinfo.insertCoinOnStartup;
+        bool? insertCoinOnStartup = cbinfo.insertCoinOnStartup;
 
 
         string CRTType = $"screen-mock-{orientation}";

--- a/Assets/curif/LibRetroWrapper/Cabinet.cs
+++ b/Assets/curif/LibRetroWrapper/Cabinet.cs
@@ -888,6 +888,7 @@ public class Cabinet
         BackgroundSoundController backgroundSoundController = _backgroundSoundController;
         string core = cbinfo.core ?? "mame2003+";
         CoreEnvironment coreEnvironment = cbinfo.environment;
+        bool insertCoinOnStartup = cbinfo.insertCoinOnStartup;
 
 
         string CRTType = $"screen-mock-{orientation}";
@@ -954,6 +955,7 @@ public class Cabinet
             libretroScreenController.EnableSaveState = EnableSaveState;
             libretroScreenController.StateFile = StateFile;
             libretroScreenController.PathBase = pathBase;
+            libretroScreenController.InsertCoinOnStartup = insertCoinOnStartup;
 
             libretroScreenController.GameInvertX = invertX;
             libretroScreenController.GameInvertY = invertY;

--- a/Assets/curif/LibRetroWrapper/CabinetInformation.cs
+++ b/Assets/curif/LibRetroWrapper/CabinetInformation.cs
@@ -73,7 +73,7 @@ public class CabinetInformation
     public string controlScheme;
 
     [YamlMember(Alias = "insert-coin-on-startup", ApplyNamingConventions = false)]
-    public bool insertCoinOnStartup = true;
+    public bool? insertCoinOnStartup;
 
     [YamlIgnore]
     public string pathBase;

--- a/Assets/curif/LibRetroWrapper/CabinetInformation.cs
+++ b/Assets/curif/LibRetroWrapper/CabinetInformation.cs
@@ -72,6 +72,9 @@ public class CabinetInformation
     [YamlMember(Alias = "control-scheme", ApplyNamingConventions = false)]
     public string controlScheme;
 
+    [YamlMember(Alias = "insert-coin-on-startup", ApplyNamingConventions = false)]
+    public bool insertCoinOnStartup = true;
+
     [YamlIgnore]
     public string pathBase;
 

--- a/Assets/curif/LibRetroWrapper/ConfigInformation.cs
+++ b/Assets/curif/LibRetroWrapper/ConfigInformation.cs
@@ -27,6 +27,7 @@ public class ConfigInformation
     public Audio audio;
     public LocomotionConfiguration locomotion;
     public Player player = new();
+    public CabinetConfiguration cabinet = CabinetDefault();
 
     public AGEBasicInformation agebasic = null;
 
@@ -186,6 +187,12 @@ public class ConfigInformation
         }
     }
 
+    public class CabinetConfiguration : ConfigInformationBase
+    {
+        [YamlMember(Alias = "insert-coin-on-startup", ApplyNamingConventions = false)]
+        public bool insertCoinOnStartup = true;
+    }
+
     // defaults ===================================================
     public static Background BackgroundInGameDefault()
     {
@@ -207,6 +214,12 @@ public class ConfigInformation
         player.height = 0f;
         player.scale = 0.9f;
         return player;
+    }
+    public static CabinetConfiguration CabinetDefault()
+    {
+        CabinetConfiguration cabinetConfiguration = new CabinetConfiguration();
+        cabinetConfiguration.insertCoinOnStartup = true;
+        return cabinetConfiguration;
     }
 
     public static ConfigInformation newDefault()

--- a/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
@@ -29,6 +29,7 @@ using UnityEditor;
 [RequireComponent(typeof(LibretroControlMap))]
 [RequireComponent(typeof(basicAGE))]
 [RequireComponent(typeof(CabinetAGEBasic))]
+[RequireComponent(typeof(ConfigurationController))]
 // [RequireComponent(typeof(BoxCollider))]
 public class LibretroScreenController : MonoBehaviour
 {
@@ -121,6 +122,7 @@ public class LibretroScreenController : MonoBehaviour
     public CabinetAGEBasicInformation ageBasicInformation;
     private CabinetAGEBasic cabinetAGEBasic;
     public BackgroundSoundController backgroundSoundController;
+    public GlobalConfiguration globalConfiguration = null;
 
     private Coroutine mainCoroutine;
     private bool initialized = false;
@@ -142,6 +144,11 @@ public class LibretroScreenController : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        GameObject GlobalConfigurationGameObject = GameObject.Find("GlobalConfiguration");
+        this.globalConfiguration = GlobalConfigurationGameObject.GetComponent<GlobalConfiguration>();
+        if (globalConfiguration == null)
+            ConfigManager.WriteConsoleError($"[LibretroScreenController.Start] {name} globalConfiguration not found.");
+
         LibretroMameCore.WriteConsole($"[LibretroScreenController.Start] {gameObject.name}");
 
         display = GetComponent<Renderer>();
@@ -313,7 +320,9 @@ public class LibretroScreenController : MonoBehaviour
 
 #if !UNITY_EDITOR
                   // start libretro
-                  if (!InsertCoinOnStartup.GetValueOrDefault(true))
+                  bool insertCoinOnStartup = InsertCoinOnStartup.HasValue ? 
+                    InsertCoinOnStartup.Value : globalConfiguration.Configuration.cabinet.insertCoinOnStartup;
+                  if (!insertCoinOnStartup)
                   {
                       CoinSlot.clean();
                   }

--- a/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
@@ -94,7 +94,7 @@ public class LibretroScreenController : MonoBehaviour
     public LightGunInformation lightGunInformation;
     public Cabinet cabinet;
     public CoreEnvironment CabEnvironment;
-    public bool InsertCoinOnStartup = true;
+    public bool? InsertCoinOnStartup;
 
     public bool SimulateExitGame;
 
@@ -313,7 +313,7 @@ public class LibretroScreenController : MonoBehaviour
 
 #if !UNITY_EDITOR
                   // start libretro
-                  if (!InsertCoinOnStartup)
+                  if (!InsertCoinOnStartup.GetValueOrDefault(true))
                   {
                       CoinSlot.clean();
                   }

--- a/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
@@ -94,6 +94,7 @@ public class LibretroScreenController : MonoBehaviour
     public LightGunInformation lightGunInformation;
     public Cabinet cabinet;
     public CoreEnvironment CabEnvironment;
+    public bool InsertCoinOnStartup = true;
 
     public bool SimulateExitGame;
 
@@ -311,6 +312,11 @@ public class LibretroScreenController : MonoBehaviour
                   }
 
 #if !UNITY_EDITOR
+                  // start libretro
+                  if (!InsertCoinOnStartup)
+                  {
+                      CoinSlot.clean();
+                  }
                   // start libretro
                   if (!LibretroMameCore.Start(ScreenName, GameFile))
                   {


### PR DESCRIPTION
In description.yaml: 
```
insert-coin-on-startup: false
```
(defaults to true since this is the regular behavior)

In configuration.yaml, there is a new section for cabinet defaults:
```
cabinet:
  insert-coin-on-startup: false
```
(also defaults to true)