### PR TITLE
  forced-shader setting, auto create download folders per core

### DIFF
--- a/Assets/curif/LibRetroWrapper/ConfigInformation.cs
+++ b/Assets/curif/LibRetroWrapper/ConfigInformation.cs
@@ -191,6 +191,9 @@ public class ConfigInformation
     {
         [YamlMember(Alias = "insert-coin-on-startup", ApplyNamingConventions = false)]
         public bool insertCoinOnStartup = true;
+
+        [YamlMember(Alias = "forced-shader", ApplyNamingConventions = false)]
+        public string forcedShader;
     }
 
     // defaults ===================================================
@@ -219,6 +222,7 @@ public class ConfigInformation
     {
         CabinetConfiguration cabinetConfiguration = new CabinetConfiguration();
         cabinetConfiguration.insertCoinOnStartup = true;
+        cabinetConfiguration.forcedShader = null;
         return cabinetConfiguration;
     }
 

--- a/Assets/curif/LibRetroWrapper/CoresController.cs
+++ b/Assets/curif/LibRetroWrapper/CoresController.cs
@@ -4,7 +4,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-#define DEBUG_CONFIG
+//#define DEBUG_CONFIG
 
 using System;
 using System.Collections.Generic;
@@ -27,9 +27,10 @@ namespace Assets.curif.LibRetroWrapper
             SyncCores();
             ScanForUserCores();
             AddEmbeddedCores();
+            CreateCoreDirs();
 
 #if DEBUG_CONFIG
-            foreach (var core in Cores)
+                foreach (var core in Cores)
             {
                 CoreEnvironment coreEnvironment = core.Value.ReadCoreEnvironment();
                 ConfigManager.WriteConsole($"[CoresController] Core {core.Key} configuration: {coreEnvironment.prefix}");
@@ -39,6 +40,14 @@ namespace Assets.curif.LibRetroWrapper
                 }
             }
 #endif
+        }
+
+        private void CreateCoreDirs()
+        {
+            foreach (var core in Cores.Values)
+            {
+                ConfigManager.CreateFolder(Path.Combine(ConfigManager.RomsDir, core.Name));
+            }
         }
 
         private void AddEmbeddedCores()

--- a/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
@@ -177,14 +177,16 @@ public class LibretroScreenController : MonoBehaviour
             ConfigManager.WriteConsoleError($"[LibretroScreenController.Start] {name} Coin Slot not found in cabinet !!!! no one can play this game.");
 
         //material and shader
-        shader = ShaderScreen.Factory(display, 1, ShaderName, ShaderConfig);
-        ConfigManager.WriteConsole($"[LibretroScreenController.Start]  {name} shader created: {shader}");
-
         // shader hack to replace the CRT for the LOD version in attraction videos (if the user select CRT)
         if (ShaderName == "crt")
             videoShader = ShaderScreen.Factory(display, 1, "crtlod", ShaderConfig);
         else
             videoShader = ShaderScreen.Factory(display, 1, "clean", ShaderConfig);
+
+        if (globalConfiguration.Configuration.cabinet.forcedShader != null)
+            ShaderName = globalConfiguration.Configuration.cabinet.forcedShader;
+        shader = ShaderScreen.Factory(display, 1, ShaderName, ShaderConfig);
+        ConfigManager.WriteConsole($"[LibretroScreenController.Start]  {name} shader created: {shader}");
 
         // age basic
         if (ageBasicInformation != null && ageBasicInformation.active)


### PR DESCRIPTION
- New setting in configuration.yaml :   forced-shader to force every cab to use a specific shader

```
cabinet:
  forced-shader: crt
``` 

- Sub-directories are now auto-created for each core in /downloads