### PR TITLE
Lightgun device id overriding

### DIFF
--- a/Assets/curif/LibRetroWrapper/LibretroMameCore.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroMameCore.cs
@@ -274,7 +274,7 @@ public static unsafe class LibretroMameCore
     private static extern void wrapper_retro_deinit();
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     private static extern int wrapper_load_game(string path, string _gamma,
-                                                        string _brightness, int xy_device);
+                                                        string _brightness, uint xy_device);
     [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
     private static extern void wrapper_unload_game();
 
@@ -514,8 +514,8 @@ public static unsafe class LibretroMameCore
         assignControls();
 
         //ligthgun
-        int xy_device = (lightGunTarget?.lightGunInformation != null &&
-                            lightGunTarget.lightGunInformation.active) ? 1 : 0;
+        uint xy_device = (lightGunTarget?.lightGunInformation != null &&
+                            lightGunTarget.lightGunInformation.active) ? lightGunTarget.lightGunInformation.device : 0;
 
         WriteConsole($"[LibRetroMameCore.Start] wrapper_load_game {GameFileName} in {ScreenName}");
         GameLoaded = wrapper_load_game(path, Gamma, Brightness, xy_device) == 1;

--- a/Assets/curif/LibRetroWrapper/LightGunTarget.cs
+++ b/Assets/curif/LibRetroWrapper/LightGunTarget.cs
@@ -8,10 +8,13 @@ using System.IO;
 
 public class LightGunInformation
 {
+    public static uint RETRO_DEVICE_LIGHTGUN = 4;
+
     public bool active = false;
     public Gun gun = new();
     public CRT crt = new();
     public Debug debug = new();
+    public uint device = RETRO_DEVICE_LIGHTGUN;
 
 
     public class Debug

--- a/Assets/curif/LibRetroWrapper/cwrapper/environment.c
+++ b/Assets/curif/LibRetroWrapper/cwrapper/environment.c
@@ -632,7 +632,8 @@ int wrapper_load_game(char* path, char* _gamma, char* _brightness,
 
 	if (_xy_control_type != 0) {
 		//there isn't a way to say "mouse" yet in others than mame2003. So it's lightgun o joypad. 
-		handlers.retro_set_controller_port_device(0, RETRO_DEVICE_LIGHTGUN);
+		handlers.retro_set_controller_port_device(0, _xy_control_type);
+		handlers.retro_set_controller_port_device(1, RETRO_DEVICE_JOYPAD);	// TODO: this actually won't be handled by us in the callback
 	}
 	else {
 		handlers.retro_set_controller_port_device(0, RETRO_DEVICE_JOYPAD);


### PR DESCRIPTION
One can now define the libretro device id for lightguns

description.yaml
```
light-gun:
  device: 260
```

260 is GunCon for swanstation.
Default value is 4 which is the regular RETRO_DEVICE_LIGHTGUN