### PR TITLE
Libretro device selection

### DIFF
--- a/Assets/curif/LibRetroWrapper/Cabinet.cs
+++ b/Assets/curif/LibRetroWrapper/Cabinet.cs
@@ -887,7 +887,7 @@ public class Cabinet
         CoreEnvironment coreEnvironment = cbinfo.environment;
         bool? insertCoinOnStartup = cbinfo.insertCoinOnStartup;
         bool? persistent = cbinfo.persistent;
-        List<LibretroInputDevice> libretroInputDevices = cbinfo.GetLibretroInputDevices();
+        Dictionary<uint, LibretroInputDevice> libretroInputDevices = cbinfo.GetLibretroInputDevices();
 
         string GameVideoFile = null;
         bool GameVideoFileInvertX = false;

--- a/Assets/curif/LibRetroWrapper/Cabinet.cs
+++ b/Assets/curif/LibRetroWrapper/Cabinet.cs
@@ -887,6 +887,7 @@ public class Cabinet
         CoreEnvironment coreEnvironment = cbinfo.environment;
         bool? insertCoinOnStartup = cbinfo.insertCoinOnStartup;
         bool? persistent = cbinfo.persistent;
+        List<LibretroInputDevice> libretroInputDevices = cbinfo.GetLibretroInputDevices();
 
         string GameVideoFile = null;
         bool GameVideoFileInvertX = false;
@@ -971,6 +972,7 @@ public class Cabinet
             libretroScreenController.cabinet = this;
             libretroScreenController.Core = core;
             libretroScreenController.Persistent = persistent;
+            libretroScreenController.LibretroInputDevices = libretroInputDevices;
 
             libretroScreenController.ShaderName = shaderName;
             libretroScreenController.ShaderConfig = shaderConfig;

--- a/Assets/curif/LibRetroWrapper/CabinetInformation.cs
+++ b/Assets/curif/LibRetroWrapper/CabinetInformation.cs
@@ -84,7 +84,7 @@ public class CabinetInformation
                 .IgnoreUnmatchedProperties()
                 .Build();
 
-    private List<LibretroInputDevice> libretroInputDevices;
+    private Dictionary<uint, LibretroInputDevice> libretroInputDevices;
 
     public CabinetInformation() { }
 
@@ -113,33 +113,35 @@ public class CabinetInformation
         }
     }
 
-    public List<LibretroInputDevice> GetLibretroInputDevices()
+    public Dictionary<uint, LibretroInputDevice> GetLibretroInputDevices()
     {
         ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: START");
         if (libretroInputDevices == null)
         {
             ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: libretroInputDevices not computed yet");
-            libretroInputDevices = new List<LibretroInputDevice>();
+            libretroInputDevices = new Dictionary<uint, LibretroInputDevice>();
             if (devices != null && devices.Count > 0)
             {
                 ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: some devices have been specified");
                 foreach (CabinetInputDevice device in devices)
                 {
                     ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: adding device type {device.type} for slot {device.slot}");
-                    LibretroInputDevice dev = LibretroInputDevice.GetInputDeviceType(device.type);
-                    ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: found device {dev.Name} of id {dev.Id}");
-                    libretroInputDevices.Add(dev);
+                    LibretroInputDevice libretroDevice = LibretroInputDevice.GetInputDeviceType(device.type);
+                    ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: found device {libretroDevice.Name} of id {libretroDevice.Id}");
+                    libretroInputDevices.Add(device.slot, libretroDevice);
                 }
-            } else
+            }
+            else
             {
+                uint idx = 0;
                 ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: no devices have been specified");
                 if (lightGunInformation != null && lightGunInformation.active)
                 {
                     ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: adding lightgun");
-                    libretroInputDevices.Add(LibretroInputDevice.Lightgun);
+                    libretroInputDevices.Add(idx++, LibretroInputDevice.Lightgun);
                 }
                 ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: adding gamepad");
-                libretroInputDevices.Add(LibretroInputDevice.Gamepad);
+                libretroInputDevices.Add(idx++, LibretroInputDevice.Gamepad);
             }
         }
         return libretroInputDevices;

--- a/Assets/curif/LibRetroWrapper/CabinetInformation.cs
+++ b/Assets/curif/LibRetroWrapper/CabinetInformation.cs
@@ -54,7 +54,7 @@ public class CabinetInformation
     public string space = "1x1x2";
     public string core = "mame2003+";
     public CoreEnvironment environment;
-
+    public List<CabinetInputDevice> devices;
 
     [YamlMember(Alias = "mame-files", ApplyNamingConventions = false)]
     public List<MameFile> MameFiles { get; set; }
@@ -84,6 +84,8 @@ public class CabinetInformation
                 .IgnoreUnmatchedProperties()
                 .Build();
 
+    private List<LibretroInputDevice> libretroInputDevices;
+
     public CabinetInformation() { }
 
     public void Validate()
@@ -109,6 +111,38 @@ public class CabinetInformation
                 CheckResourcePath(mf?.file);
             }
         }
+    }
+
+    public List<LibretroInputDevice> GetLibretroInputDevices()
+    {
+        ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: START");
+        if (libretroInputDevices == null)
+        {
+            ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: libretroInputDevices not computed yet");
+            libretroInputDevices = new List<LibretroInputDevice>();
+            if (devices != null && devices.Count > 0)
+            {
+                ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: some devices have been specified");
+                foreach (CabinetInputDevice device in devices)
+                {
+                    ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: adding device type {device.type} for slot {device.slot}");
+                    LibretroInputDevice dev = LibretroInputDevice.GetInputDeviceType(device.type);
+                    ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: found device {dev.Name} of id {dev.Id}");
+                    libretroInputDevices.Add(dev);
+                }
+            } else
+            {
+                ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: no devices have been specified");
+                if (lightGunInformation != null && lightGunInformation.active)
+                {
+                    ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: adding lightgun");
+                    libretroInputDevices.Add(LibretroInputDevice.Lightgun);
+                }
+                ConfigManager.WriteConsole($"[CabinetInformation.GetLibretroInputDevices]: adding gamepad");
+                libretroInputDevices.Add(LibretroInputDevice.Gamepad);
+            }
+        }
+        return libretroInputDevices;
     }
 
     public static void CheckResourcePath(string path)
@@ -301,6 +335,12 @@ public class CabinetInformation
         public string type = Types[0];
         public Geometry geometry = new Geometry();
         public Marquee marquee = new Marquee();
+    }
+
+    public class CabinetInputDevice
+    {
+        public uint slot;
+        public string type;
     }
 
     public class CRT

--- a/Assets/curif/LibRetroWrapper/LibretroInputDevice.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroInputDevice.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+
+public class LibretroInputDevice
+{
+    private static int RETRO_DEVICE_TYPE_SHIFT = 8;
+    private static uint RETRO_DEVICE_SUBCLASS(uint _base, uint _id)
+    {
+        return (((_id + 1) << RETRO_DEVICE_TYPE_SHIFT) | _base);
+    }
+
+    // Standard libretro devices
+    private static uint RETRO_DEVICE_NONE = 0;
+    private static uint RETRO_DEVICE_JOYPAD = 1;
+    private static uint RETRO_DEVICE_MOUSE = 2;
+    private static uint RETRO_DEVICE_KEYBOARD = 3;
+    private static uint RETRO_DEVICE_LIGHTGUN = 4;
+    private static uint RETRO_DEVICE_ANALOG = 5;
+    private static uint RETRO_DEVICE_POINTER = 6;
+
+    // PSX devices
+    private static uint RETRO_DEVICE_PSE_STANDARD = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 0);
+    private static uint RETRO_DEVICE_PSE_ANALOG = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 0);
+    private static uint RETRO_DEVICE_PSE_DUALSHOCK = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 1);
+    private static uint RETRO_DEVICE_PSE_NEGCON = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 2);
+    private static uint RETRO_DEVICE_PSE_GUNCON = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_LIGHTGUN, 0);
+    private static uint RETRO_DEVICE_PSE_JUSTIFIER = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_LIGHTGUN, 1);
+    private static uint RETRO_DEVICE_PSE_MOUSE = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 0);
+
+    // SNES9X devices
+    private static uint RETRO_DEVICE_LIGHTGUN_SUPER_SCOPE = ((1 << 8) | RETRO_DEVICE_LIGHTGUN);
+    private static uint RETRO_DEVICE_LIGHTGUN_JUSTIFIER = ((2 << 8) | RETRO_DEVICE_LIGHTGUN);
+    private static uint RETRO_DEVICE_LIGHTGUN_JUSTIFIER_2 = (3 << 8) | RETRO_DEVICE_LIGHTGUN;
+    private static uint RETRO_DEVICE_LIGHTGUN_MACS_RIFLE = ((4 << 8) | RETRO_DEVICE_LIGHTGUN);
+
+    // GenesisPlusGX devices
+    private static uint RETRO_DEVICE_PHASER = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_LIGHTGUN, 0);
+    private static uint RETRO_DEVICE_MENACER = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_LIGHTGUN, 1);
+    private static uint RETRO_DEVICE_JUSTIFIERS = RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_LIGHTGUN, 2);
+
+    public static LibretroInputDevice Empty = new LibretroInputDevice("empty", RETRO_DEVICE_NONE);
+    public static LibretroInputDevice Gamepad = new LibretroInputDevice("gamepad", RETRO_DEVICE_JOYPAD);
+    public static LibretroInputDevice Mouse = new LibretroInputDevice("mouse", RETRO_DEVICE_MOUSE);
+    public static LibretroInputDevice Keyboard = new LibretroInputDevice("keyboard", RETRO_DEVICE_KEYBOARD);
+    public static LibretroInputDevice Lightgun = new LibretroInputDevice("lightgun", RETRO_DEVICE_LIGHTGUN);
+    public static LibretroInputDevice Analog = new LibretroInputDevice("analog", RETRO_DEVICE_ANALOG);
+    public static LibretroInputDevice Pointer = new LibretroInputDevice("pointer", RETRO_DEVICE_POINTER);
+
+    public static LibretroInputDevice PsxStandard = new LibretroInputDevice("psx_standard", RETRO_DEVICE_PSE_STANDARD);
+    public static LibretroInputDevice PsxAnalog = new LibretroInputDevice("psx_analog", RETRO_DEVICE_PSE_ANALOG);
+    public static LibretroInputDevice PsxDualShock = new LibretroInputDevice("psx_dual_shock", RETRO_DEVICE_PSE_DUALSHOCK);
+    public static LibretroInputDevice PsxNegCon = new LibretroInputDevice("psx_negcon", RETRO_DEVICE_PSE_NEGCON);
+    public static LibretroInputDevice PsxGunCon = new LibretroInputDevice("psx_guncon", RETRO_DEVICE_PSE_GUNCON);
+    public static LibretroInputDevice PsxJustifier = new LibretroInputDevice("psx_justifier", RETRO_DEVICE_PSE_JUSTIFIER);
+    public static LibretroInputDevice PsxMouse = new LibretroInputDevice("psx_mouse", RETRO_DEVICE_PSE_MOUSE);
+
+    public static LibretroInputDevice SnesSuperScope = new LibretroInputDevice("snes_superscope", RETRO_DEVICE_LIGHTGUN_SUPER_SCOPE);
+    public static LibretroInputDevice SnesJustifier = new LibretroInputDevice("snes_justifier", RETRO_DEVICE_LIGHTGUN_JUSTIFIER);
+    public static LibretroInputDevice SnesJustifier2 = new LibretroInputDevice("snes_justifier_2", RETRO_DEVICE_LIGHTGUN_JUSTIFIER_2);
+    public static LibretroInputDevice SnesMacsRifle = new LibretroInputDevice("snes_macs_rifle", RETRO_DEVICE_LIGHTGUN_MACS_RIFLE);
+
+    public static LibretroInputDevice GenesisPhaser = new LibretroInputDevice("sega_phaser", RETRO_DEVICE_PHASER);
+    public static LibretroInputDevice GenesisMenacer = new LibretroInputDevice("sega_menacer", RETRO_DEVICE_MENACER);
+    public static LibretroInputDevice GenesisJustifiers = new LibretroInputDevice("sega_justifiers", RETRO_DEVICE_JUSTIFIERS);
+
+
+    public static Dictionary<string, LibretroInputDevice> keyValuePairs = new Dictionary<string, LibretroInputDevice>
+    {
+        { Empty.Name, Empty },
+        { Gamepad.Name, Gamepad },
+        { Mouse.Name, Mouse },
+        { Keyboard.Name, Keyboard },
+        { Lightgun.Name, Lightgun },
+        { Analog.Name, Analog },
+        { Pointer.Name, Pointer },
+        { PsxStandard.Name, PsxStandard },
+        { PsxAnalog.Name, PsxAnalog },
+        { PsxDualShock.Name, PsxDualShock },
+        { PsxNegCon.Name, PsxNegCon },
+        { PsxGunCon.Name, PsxGunCon },
+        { PsxJustifier.Name, PsxJustifier },
+        { PsxMouse.Name, PsxMouse},
+        { SnesSuperScope.Name, SnesSuperScope },
+        { SnesJustifier.Name, SnesJustifier },
+        { SnesJustifier2.Name, SnesJustifier2 },
+        { SnesMacsRifle.Name, SnesMacsRifle },
+        { GenesisPhaser.Name, GenesisPhaser },
+        { GenesisMenacer.Name, GenesisMenacer },
+        { GenesisJustifiers.Name, GenesisJustifiers }
+    };
+
+    public static LibretroInputDevice GetInputDeviceType(string name)
+    {
+        if (name.StartsWith("device_"))
+        {
+            return new LibretroInputDevice(name, uint.Parse(name.Substring(7)));
+        }
+
+        if (keyValuePairs.ContainsKey(name)) { return keyValuePairs[name]; }
+        return Empty;
+    }
+
+    public string Name { get; }
+    public uint Id { get; }
+
+    private LibretroInputDevice(string name, uint id)
+    {
+        this.Name = name;
+        this.Id = id;
+    }
+}

--- a/Assets/curif/LibRetroWrapper/LibretroInputDevice.cs.meta
+++ b/Assets/curif/LibRetroWrapper/LibretroInputDevice.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f3a135839a7d1a45b64342cbdf2aac8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/curif/LibRetroWrapper/LibretroMameCore.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroMameCore.cs
@@ -249,7 +249,7 @@ public static unsafe class LibretroMameCore
     static bool InteractionAvailable = false;
 
     public static LightGunTarget lightGunTarget;
-    public static List<LibretroInputDevice> libretroInputDevices;
+    public static Dictionary<uint, LibretroInputDevice> libretroInputDevices;
 
 #if _debug_fps_
     //Profiling
@@ -519,11 +519,13 @@ public static unsafe class LibretroMameCore
         }
 
         // set up input ports
-        uint port = 0;
         foreach (var device in libretroInputDevices)
         {
-            WriteConsole($"[LibRetroMameCore.Start] Setting controller port device {port} to {device.Name}:{device.Id}");
-            wrapper_set_controller_port_device(port++, device.Id);
+            uint port = device.Key;
+            uint deviceId= device.Value.Id;
+            string deviceName = device.Value.Name;
+            WriteConsole($"[LibRetroMameCore.Start] Setting controller port device {port} to {deviceName}:{deviceId}");
+            wrapper_set_controller_port_device(port, deviceId);
         }
 
 #if !UNITY_EDITOR

--- a/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
@@ -101,7 +101,7 @@ public class LibretroScreenController : MonoBehaviour
     public Cabinet cabinet;
     public CoreEnvironment CabEnvironment;
     public bool? InsertCoinOnStartup;
-    public List<LibretroInputDevice> LibretroInputDevices;
+    public Dictionary<uint, LibretroInputDevice> LibretroInputDevices;
 
     public bool SimulateExitGame;
 

--- a/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroScreenController.cs
@@ -101,6 +101,7 @@ public class LibretroScreenController : MonoBehaviour
     public Cabinet cabinet;
     public CoreEnvironment CabEnvironment;
     public bool? InsertCoinOnStartup;
+    public List<LibretroInputDevice> LibretroInputDevices;
 
     public bool SimulateExitGame;
 
@@ -325,6 +326,8 @@ public class LibretroScreenController : MonoBehaviour
                       lightGunTarget.Init(lightGunInformation, PathBase);
                       LibretroMameCore.lightGunTarget = lightGunTarget;
                   }
+
+                  LibretroMameCore.libretroInputDevices = LibretroInputDevices;
 
 #if !UNITY_EDITOR
                   // start libretro

--- a/Assets/curif/LibRetroWrapper/LightGunTarget.cs
+++ b/Assets/curif/LibRetroWrapper/LightGunTarget.cs
@@ -8,14 +8,10 @@ using System.IO;
 
 public class LightGunInformation
 {
-    public static uint RETRO_DEVICE_LIGHTGUN = 4;
-
     public bool active = false;
     public Gun gun = new();
     public CRT crt = new();
     public Debug debug = new();
-    public uint device = RETRO_DEVICE_LIGHTGUN;
-
 
     public class Debug
     {

--- a/Assets/curif/LibRetroWrapper/cwrapper/environment.c
+++ b/Assets/curif/LibRetroWrapper/cwrapper/environment.c
@@ -624,24 +624,22 @@ int wrapper_load_game(char* path, char* _gamma, char* _brightness,
 
 	wrapper_image_prev_load_game();
 	wrapper_environment_set_game_parameters(
-		_gamma, _brightness, _xy_control_type); // 0 mouse, 1 ligthgun
+		_gamma, _brightness, _xy_control_type); // 0 mouse, 1 lightgun
 
 	wrapper_environment_log(RETRO_LOG_INFO, "[wrapper_load_game] (%s)--\n",
 		game_info.path);
 	bool ret = handlers.retro_load_game(&game_info);
-
-	if (_xy_control_type != 0) {
-		//there isn't a way to say "mouse" yet in others than mame2003. So it's lightgun o joypad. 
-		handlers.retro_set_controller_port_device(0, _xy_control_type);
-		handlers.retro_set_controller_port_device(1, RETRO_DEVICE_JOYPAD);	// TODO: this actually won't be handled by us in the callback
-	}
-	else {
-		handlers.retro_set_controller_port_device(0, RETRO_DEVICE_JOYPAD);
-	}
-
+	
 	wrapper_environment_log(RETRO_LOG_INFO,
 		"[wrapper_load_game] END (ret:%i) --------- \n", ret);
 	return (int)ret;
+}
+
+void wrapper_set_controller_port_device(unsigned port, unsigned device) {
+	wrapper_environment_log(RETRO_LOG_INFO,
+		"[wrapper_set_controller_port_device] port: %i device: %i\n", port,
+		device);
+	handlers.retro_set_controller_port_device(port, device);
 }
 
 void wrapper_unload_game() {

--- a/Assets/curif/LibRetroWrapper/cwrapper/environment.h
+++ b/Assets/curif/LibRetroWrapper/cwrapper/environment.h
@@ -72,6 +72,7 @@ bool wrapper_set_savestate_data(void* data, size_t size);
 bool wrapper_get_savestate_data(void* data, size_t size);
 size_t wrapper_get_memory_size(unsigned id);
 void* wrapper_get_memory_data(unsigned id);
+void wrapper_set_controller_port_device(unsigned port, unsigned device);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Allow precise control of libretro device useage (defined at cab level)

eg:

This is a lightgun PSX game
```
devices:
  - slot: 0
    type: psx_guncon
  - slot: 1
    type: gamepad
```

This is a ScummVM game
```
devices:
  - slot: 0
    type: mouse
```

If no `devices` block is present in the cab configuration, AoJ will auto-add a regular lightgun if that's a lightgun cab, or a regular pad otherwise.

The `LibretroInputDevice` class defines many ready-to-use devices.
But user is free to specify a device id (number) for a device that's was not provisionned in this catalogue, by using the `device_[value]` pattern.




