### PR TITLE
New mouse input device: "mouse_pointer", emulates mouse with aiming rather than sticks

### DIFF
--- a/Assets/curif/LibRetroWrapper/LibretroInputDevice.cs
+++ b/Assets/curif/LibRetroWrapper/LibretroInputDevice.cs
@@ -39,7 +39,8 @@ public class LibretroInputDevice
 
     public static LibretroInputDevice Empty = new LibretroInputDevice("empty", RETRO_DEVICE_NONE);
     public static LibretroInputDevice Gamepad = new LibretroInputDevice("gamepad", RETRO_DEVICE_JOYPAD);
-    public static LibretroInputDevice Mouse = new LibretroInputDevice("mouse", RETRO_DEVICE_MOUSE);
+    public static LibretroInputDevice Mouse = new LibretroInputDevice("mouse", RETRO_DEVICE_MOUSE, "stick");
+    public static LibretroInputDevice MousePointer = new LibretroInputDevice("mouse_pointer", RETRO_DEVICE_MOUSE, "aim");
     public static LibretroInputDevice Keyboard = new LibretroInputDevice("keyboard", RETRO_DEVICE_KEYBOARD);
     public static LibretroInputDevice Lightgun = new LibretroInputDevice("lightgun", RETRO_DEVICE_LIGHTGUN);
     public static LibretroInputDevice Analog = new LibretroInputDevice("analog", RETRO_DEVICE_ANALOG);
@@ -68,6 +69,7 @@ public class LibretroInputDevice
         { Empty.Name, Empty },
         { Gamepad.Name, Gamepad },
         { Mouse.Name, Mouse },
+        { MousePointer.Name, MousePointer },
         { Keyboard.Name, Keyboard },
         { Lightgun.Name, Lightgun },
         { Analog.Name, Analog },
@@ -102,9 +104,16 @@ public class LibretroInputDevice
     public string Name { get; }
     public uint Id { get; }
 
-    private LibretroInputDevice(string name, uint id)
+    public string Type { get; }
+
+    private LibretroInputDevice(string name, uint id, string type)
     {
         this.Name = name;
         this.Id = id;
+        this.Type = type;
+    }
+
+    private LibretroInputDevice(string name, uint id) : this(name, id, default(string))
+    {
     }
 }


### PR DESCRIPTION
New device for emulating mouse with aiming rather than analog sticks: use `mouse_pointer` instead of `mouse`.

In order to use `mouse_pointer` you also need to add the usual lightgun configuration block to your cab !

Example: 
```
core: scummvm
rom: Day of the Tentacle.scummvm

devices:
  - slot: 0
    type: mouse_pointer

light-gun:
  active: true
  gun:
    invert-pointer: false
    model: bullpuprifle.glb
    adjust-sight:
      horizontal: 0
      vertical: 6  
  debug:
    active: false
```