### PR TITLE
Fix rendering errors

### DIFF
--- a/Assets/Resources/Architecture/dungeon/LightWoodStandard.mat
+++ b/Assets/Resources/Architecture/dungeon/LightWoodStandard.mat
@@ -25,7 +25,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _BumpMap:
-        m_Texture: {fileID: 2800000, guid: ead3a835a15c2ed018dd8be9ad5b97d0, type: 3}
+        m_Texture: {fileID: 2800000, guid: 8b7227460adbb514b88cac249f717677, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:

--- a/Assets/Resources/Cabinets/Materials/CabinetBlue.mat
+++ b/Assets/Resources/Cabinets/Materials/CabinetBlue.mat
@@ -25,7 +25,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _BumpMap:
-        m_Texture: {fileID: 2800000, guid: ead3a835a15c2ed018dd8be9ad5b97d0, type: 3}
+        m_Texture: {fileID: 2800000, guid: 8b7227460adbb514b88cac249f717677, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:

--- a/Assets/Resources/Cabinets/Materials/DarkWoodStandard.mat
+++ b/Assets/Resources/Cabinets/Materials/DarkWoodStandard.mat
@@ -25,7 +25,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _BumpMap:
-        m_Texture: {fileID: 2800000, guid: ead3a835a15c2ed018dd8be9ad5b97d0, type: 3}
+        m_Texture: {fileID: 2800000, guid: 8b7227460adbb514b88cac249f717677, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:

--- a/Assets/Resources/Cabinets/Materials/LightWoodStandard.mat
+++ b/Assets/Resources/Cabinets/Materials/LightWoodStandard.mat
@@ -25,7 +25,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _BumpMap:
-        m_Texture: {fileID: 2800000, guid: ead3a835a15c2ed018dd8be9ad5b97d0, type: 3}
+        m_Texture: {fileID: 2800000, guid: 8b7227460adbb514b88cac249f717677, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:


### PR DESCRIPTION
Fixed materials rendering strrangely when non-normal maps are assigned to the normal slot. 