### PR TITLE
Add keyboard mappings for X-Arcade Arcade2TV-XR

### DIFF
--- a/Assets/curif/LibRetroWrapper/ControlMapConfiguration.cs
+++ b/Assets/curif/LibRetroWrapper/ControlMapConfiguration.cs
@@ -225,22 +225,24 @@ public class DefaultControlMap : ControlMapConfiguration
         AddMap(LC.MODIFIER, new string[] { CM.VR_CONTROLLER_LEFT_GRIP });
 
         //fire with b-button and trigger.
-        AddMap(LC.JOYPAD_B, new string[] { CM.VR_CONTROLLER_B, CM.GAMEPAD_B, CM.KEYBOARD_ENTER });
-        AddMap(LC.JOYPAD_A, new string[] { CM.GAMEPAD_A, CM.VR_CONTROLLER_A });
-        AddMap(LC.JOYPAD_X, new string[] { CM.GAMEPAD_X, CM.VR_CONTROLLER_X });
-        AddMap(LC.JOYPAD_Y, new string[] { CM.GAMEPAD_Y, CM.VR_CONTROLLER_Y });
-        AddMap(LC.JOYPAD_START, new string[] { CM.GAMEPAD_START, CM.VR_CONTROLLER_START });
-        AddMap(LC.JOYPAD_SELECT, new string[] { CM.GAMEPAD_SELECT, CM.VR_CONTROLLER_SELECT });
+        AddMap(LC.JOYPAD_B, new string[] { CM.VR_CONTROLLER_B, CM.GAMEPAD_B, CM.KEYBOARD_ENTER, CM.KEYBOARD_W, CM.KEYBOARD_1 });
+        AddMap(LC.JOYPAD_A, new string[] { CM.GAMEPAD_A, CM.VR_CONTROLLER_A, CM.KEYBOARD_Q, CM.KEYBOARD_0 });
+        AddMap(LC.JOYPAD_X, new string[] { CM.GAMEPAD_X, CM.VR_CONTROLLER_X, CM.KEYBOARD_E, CM.KEYBOARD_2 });
+        AddMap(LC.JOYPAD_Y, new string[] { CM.GAMEPAD_Y, CM.VR_CONTROLLER_Y, CM.KEYBOARD_R, CM.KEYBOARD_3 });
+        AddMap(LC.JOYPAD_START, new string[] { CM.GAMEPAD_START, CM.VR_CONTROLLER_START, CM.KEYBOARD_I });
+        //some games (like Ms Pac-Man/Galaga 20th Anniversary) use the Player 2 start button to select a different game
+        AddMap(LC.JOYPAD_START, new string[] { CM.KEYBOARD_7 }, "button", 2);
+        AddMap(LC.JOYPAD_SELECT, new string[] { CM.GAMEPAD_SELECT, CM.VR_CONTROLLER_SELECT,CM.KEYBOARD_U,CM.KEYBOARD_6 });
 
         AddMap(LC.JOYPAD_UP, new string[] { CM.VR_CONTROLLER_LEFT_THUMBSTICK, CM.GAMEPAD_LEFT_THUMBSTICK }, "axis");
         AddMap(LC.JOYPAD_DOWN, new string[] { CM.VR_CONTROLLER_LEFT_THUMBSTICK, CM.GAMEPAD_LEFT_THUMBSTICK }, "axis");
         AddMap(LC.JOYPAD_RIGHT, new string[] { CM.VR_CONTROLLER_LEFT_THUMBSTICK, CM.GAMEPAD_LEFT_THUMBSTICK }, "axis");
         AddMap(LC.JOYPAD_LEFT, new string[] { CM.VR_CONTROLLER_LEFT_THUMBSTICK, CM.GAMEPAD_LEFT_THUMBSTICK }, "axis");
 
-        AddMap(LC.JOYPAD_UP, new string[] { CM.GAMEPAD_DPAD_UP });
-        AddMap(LC.JOYPAD_DOWN, new string[] { CM.GAMEPAD_DPAD_DOWN });
-        AddMap(LC.JOYPAD_RIGHT, new string[] { CM.GAMEPAD_DPAD_RIGHT });
-        AddMap(LC.JOYPAD_LEFT, new string[] { CM.GAMEPAD_DPAD_LEFT });
+        AddMap(LC.JOYPAD_UP, new string[] { CM.GAMEPAD_DPAD_UP, CM.KEYBOARD_A, CM.KEYBOARD_Z });
+        AddMap(LC.JOYPAD_DOWN, new string[] { CM.GAMEPAD_DPAD_DOWN, CM.KEYBOARD_S, CM.KEYBOARD_X });
+        AddMap(LC.JOYPAD_RIGHT, new string[] { CM.GAMEPAD_DPAD_RIGHT, CM.KEYBOARD_F, CM.KEYBOARD_V });
+        AddMap(LC.JOYPAD_LEFT, new string[] { CM.GAMEPAD_DPAD_LEFT, CM.KEYBOARD_D, CM.KEYBOARD_C });
 
         //also map port 1 to the right one (roboton issue #204)
         AddMap(LC.JOYPAD_UP, new string[] { CM.VR_CONTROLLER_RIGHT_THUMBSTICK, CM.GAMEPAD_RIGHT_THUMBSTICK }, "axis", 1);
@@ -251,17 +253,17 @@ public class DefaultControlMap : ControlMapConfiguration
         AddMap(LC.JOYPAD_LEFT_RUMBLE, new string[] { CM.VR_CONTROLLER_LEFT_HAPTIC_DEVICE });
         AddMap(LC.JOYPAD_RIGHT_RUMBLE, new string[] { CM.VR_CONTROLLER_RIGHT_HAPTIC_DEVICE });
 
-        AddMap(LC.JOYPAD_L, new string[] { CM.VR_CONTROLLER_LEFT_TRIGGER, CM.GAMEPAD_LEFT_TRIGGER });
-        AddMap(LC.JOYPAD_R, new string[] { CM.VR_CONTROLLER_RIGHT_TRIGGER, CM.GAMEPAD_RIGHT_TRIGGER });
+        AddMap(LC.JOYPAD_L, new string[] { CM.VR_CONTROLLER_LEFT_TRIGGER, CM.GAMEPAD_LEFT_TRIGGER, CM.KEYBOARD_Y, CM.KEYBOARD_5 });
+        AddMap(LC.JOYPAD_R, new string[] { CM.VR_CONTROLLER_RIGHT_TRIGGER, CM.GAMEPAD_RIGHT_TRIGGER, CM.KEYBOARD_O, CM.KEYBOARD_8 });
 
-        AddMap(LC.JOYPAD_L2, new string[] { CM.VR_CONTROLLER_LEFT_GRIP, CM.GAMEPAD_LEFT_BUMPER });
-        AddMap(LC.JOYPAD_R2, new string[] { CM.VR_CONTROLLER_RIGHT_GRIP, CM.GAMEPAD_RIGHT_BUMPER });
+        AddMap(LC.JOYPAD_L2, new string[] { CM.VR_CONTROLLER_LEFT_GRIP, CM.GAMEPAD_LEFT_BUMPER, CM.KEYBOARD_T, CM.KEYBOARD_4 });
+        AddMap(LC.JOYPAD_R2, new string[] { CM.VR_CONTROLLER_RIGHT_GRIP, CM.GAMEPAD_RIGHT_BUMPER, CM.KEYBOARD_P, CM.KEYBOARD_9 });
 
         AddMap(LC.JOYPAD_L3, new string[] { CM.VR_CONTROLLER_LEFT_THUMBSTICK_PRESS, CM.GAMEPAD_LEFT_THUMBSTICK_PRESS });
         AddMap(LC.JOYPAD_R3, new string[] { CM.VR_CONTROLLER_RIGHT_THUMBSTICK_PRESS, CM.GAMEPAD_RIGHT_THUMBSTICK_PRESS });
 
         AddMap(LC.EXIT, new string[] { CM.VR_CONTROLLER_RIGHT_GRIP, CM.GAMEPAD_LEFT_BUMPER, CM.KEYBOARD_ESC });
-        AddMap(LC.INSERT, CM.GAMEPAD_SELECT);
+        AddMap(LC.INSERT, new string[] { CM.GAMEPAD_SELECT, CM.KEYBOARD_U, CM.KEYBOARD_6 });
 
         AddMap(LC.MOUSE_X, new string[] { CM.VR_CONTROLLER_RIGHT_THUMBSTICK, CM.GAMEPAD_RIGHT_THUMBSTICK, CM.MOUSE }, "axis");
         AddMap(LC.MOUSE_Y, new string[] { CM.VR_CONTROLLER_RIGHT_THUMBSTICK, CM.GAMEPAD_RIGHT_THUMBSTICK, CM.MOUSE }, "axis");

--- a/Assets/curif/LibRetroWrapper/ControlMapPathDictionary.cs
+++ b/Assets/curif/LibRetroWrapper/ControlMapPathDictionary.cs
@@ -50,6 +50,29 @@ public static class ControlMapPathDictionary
     public const string KEYBOARD_ENTER = "keyboard-enter";
     public const string KEYBOARD_X = "keyboard-x";
     public const string KEYBOARD_Y = "keyboard-y";
+    //Adding X-Arcade Arcade2TV-XR keyboard mode mappings (works for Gen 1 dongle and 2 dongle in keyboard/"red" mode)
+    public const string KEYBOARD_F = "keyboard-f";
+    public const string KEYBOARD_Q = "keyboard-q";
+    public const string KEYBOARD_E = "keyboard-e";
+    public const string KEYBOARD_R = "keyboard-r";
+    public const string KEYBOARD_T = "keyboard-t";
+    public const string KEYBOARD_U = "keyboard-u";
+    public const string KEYBOARD_I = "keyboard-i";
+    public const string KEYBOARD_O = "keyboard-o";
+    public const string KEYBOARD_P = "keyboard-p";
+    public const string KEYBOARD_Z = "keyboard-z";
+    public const string KEYBOARD_C = "keyboard-c";
+    public const string KEYBOARD_V = "keyboard-v";
+    public const string KEYBOARD_0 = "keyboard-0";
+    public const string KEYBOARD_1 = "keyboard-1";
+    public const string KEYBOARD_2 = "keyboard-2";
+    public const string KEYBOARD_3 = "keyboard-3";
+    public const string KEYBOARD_4 = "keyboard-4";
+    public const string KEYBOARD_5 = "keyboard-5";
+    public const string KEYBOARD_6 = "keyboard-6";
+    public const string KEYBOARD_7 = "keyboard-7";
+    public const string KEYBOARD_8 = "keyboard-8";
+    public const string KEYBOARD_9 = "keyboard-9";
     public const string MOUSE = "mouse";
     public const string MOUSE_LEFT = "mouse-left";
     public const string MOUSE_RIGHT = "mouse-right";
@@ -135,7 +158,29 @@ public static class ControlMapPathDictionary
             { KEYBOARD_ESC, "<keyboard>/escape" },
             { KEYBOARD_ENTER, "<keyboard>/enter" },
             { KEYBOARD_X, "<keyboard>/#(x)" },
-            { KEYBOARD_Y, "<Keyboard>/#(y)" }
+            { KEYBOARD_Y, "<Keyboard>/#(y)" },
+            { KEYBOARD_F, "<Keyboard>/#(f)" },
+            { KEYBOARD_Q, "<Keyboard>/#(q)" },
+            { KEYBOARD_E, "<Keyboard>/#(e)" },
+            { KEYBOARD_R, "<Keyboard>/#(r)" },
+            { KEYBOARD_T, "<Keyboard>/#(t)" },
+            { KEYBOARD_U, "<Keyboard>/#(u)" },
+            { KEYBOARD_I, "<Keyboard>/#(i)" },
+            { KEYBOARD_O, "<Keyboard>/#(o)" },
+            { KEYBOARD_P, "<Keyboard>/#(p)" },
+            { KEYBOARD_Z, "<Keyboard>/#(z)" },
+            { KEYBOARD_C, "<Keyboard>/#(c)" },
+            { KEYBOARD_V, "<Keyboard>/#(v)" },
+            { KEYBOARD_0, "<Keyboard>/#(0)" },
+            { KEYBOARD_1, "<Keyboard>/#(1)" },
+            { KEYBOARD_2, "<Keyboard>/#(2)" },
+            { KEYBOARD_3, "<Keyboard>/#(3)" },
+            { KEYBOARD_4, "<Keyboard>/#(4)" },
+            { KEYBOARD_5, "<Keyboard>/#(5)" },
+            { KEYBOARD_6, "<Keyboard>/#(6)" },
+            { KEYBOARD_7, "<Keyboard>/#(7)" },
+            { KEYBOARD_8, "<Keyboard>/#(8)" },
+            { KEYBOARD_9, "<Keyboard>/#(9)" }
         };
     }
     public static string GetBehavior(string realControl)


### PR DESCRIPTION
Hardcoding the X-Arcade Arcade2TV-XR keyboard mode* mappings to the default controller configuration. This eliminates the need to define these mappings in global.yaml or any cabinet-specific configuration. Both Player 1 and Player 2 buttons and sticks are mapped to Player 1 for versatility, so you could use the Player 1 stick with Player 1 or 2 buttons, or the Player 2 stick with Player 1 or 2 Buttons. You can still provide an override YAML mappinf file if you do not want this mapping (for example for dual-stick games like Robotron).

* The Gen1 dongle only supports Keyboard mode, but the new Gen2 dongle has multiple modes, and keyboard mode is the "red" mode. The "Green" mode is X-Input mode and can also be used instead, since the stick is then treated as a gamepad device instead, and is already supported by AgeOfJoy.

